### PR TITLE
20321 fix consistent interpolations check

### DIFF
--- a/lib/i18n/tasks/interpolations.rb
+++ b/lib/i18n/tasks/interpolations.rb
@@ -3,25 +3,30 @@
 module I18n::Tasks
   module Interpolations
     class << self
-      attr_accessor :variable_regex
+      attr_accessor :variable_regex, :tag_pairs, :tag_with_localized_value_regex
     end
-    @variable_regex = /%{[^}]+}/.freeze
+    @variable_regex = /%\{[^}]+\}|\{\{.*?\}\}|\{%.*?%\}/.freeze
+    @tag_pairs = [
+      ['{{', '}}'],
+      ['%{', '}'],
+      ['{%', '%}']
+    ].freeze
+    @tag_with_localized_value_regex = /\{\{\s?(("[^"]+")|('[^']+'))\s?\|.*?\}\}/
 
     def inconsistent_interpolations(locales: nil, base_locale: nil) # rubocop:disable Metrics/AbcSize
       locales ||= self.locales
       base_locale ||= self.base_locale
       result = empty_forest
-      variable_regex = I18n::Tasks::Interpolations.variable_regex
 
       data[base_locale].key_values.each do |key, value|
         next if !value.is_a?(String) || ignore_key?(key, :inconsistent_interpolations)
 
-        base_vars = Set.new(value.scan(variable_regex))
+        base_vars = get_normalized_variables_set(value)
         (locales - [base_locale]).each do |current_locale|
           node = data[current_locale].first.children[key]
           next unless node&.value.is_a?(String)
 
-          if base_vars != Set.new(node.value.scan(variable_regex))
+          if base_vars != get_normalized_variables_set(node.value)
             result.merge!(node.walk_to_root.reduce(nil) { |c, p| [p.derive(children: c)] })
           end
         end
@@ -29,6 +34,28 @@ module I18n::Tasks
 
       result.each { |root| root.data[:type] = :inconsistent_interpolations }
       result
+    end
+
+    def get_normalized_variables_set(string)
+      Set.new(string.scan(I18n::Tasks::Interpolations.variable_regex).map { |variable| normalize(variable) })
+    end
+
+    def normalize(variable)
+      normalized = nil
+      if (match = variable.match(I18n::Tasks::Interpolations.tag_with_localized_value_regex))
+        variable = variable.sub(match[1], 'localized input')
+      end
+      I18n::Tasks::Interpolations.tag_pairs.each do |start, end_|
+        next unless variable.start_with?(start)
+
+        normalized = variable.delete_prefix(start).delete_suffix(end_).strip
+        normalized = start + normalized + end_
+        break
+      end
+
+      fail 'No start/end tag pair detected' if normalized.nil?
+
+      normalized
     end
   end
 end

--- a/lib/i18n/tasks/translators/base_translator.rb
+++ b/lib/i18n/tasks/translators/base_translator.rb
@@ -104,7 +104,7 @@ module I18n::Tasks
         end
       end
 
-      INTERPOLATION_KEY_RE = /%\{[^\}]+\}|\{\{.*?\}\}|\{%.*?%\}/.freeze
+      INTERPOLATION_KEY_RE = /%\{[^}]+\}|\{\{.*?\}\}|\{%.*?%\}/.freeze
       UNTRANSLATABLE_STRING = 'X__'
 
       # @param [String] value

--- a/lib/i18n/tasks/translators/base_translator.rb
+++ b/lib/i18n/tasks/translators/base_translator.rb
@@ -104,7 +104,7 @@ module I18n::Tasks
         end
       end
 
-      INTERPOLATION_KEY_RE = /%\{[^}]+}/.freeze
+      INTERPOLATION_KEY_RE = /%\{[^\}]+\}|\{\{.*\}\}|\{%.*%\}/.freeze
       UNTRANSLATABLE_STRING = 'X__'
 
       # @param [String] value

--- a/lib/i18n/tasks/translators/base_translator.rb
+++ b/lib/i18n/tasks/translators/base_translator.rb
@@ -104,7 +104,7 @@ module I18n::Tasks
         end
       end
 
-      INTERPOLATION_KEY_RE = /%\{[^\}]+\}|\{\{.*\}\}|\{%.*%\}/.freeze
+      INTERPOLATION_KEY_RE = /%\{[^\}]+\}|\{\{.*?\}\}|\{%.*?%\}/.freeze
       UNTRANSLATABLE_STRING = 'X__'
 
       # @param [String] value

--- a/lib/i18n/tasks/translators/deepl_translator.rb
+++ b/lib/i18n/tasks/translators/deepl_translator.rb
@@ -23,6 +23,11 @@ module I18n::Tasks::Translators
 
     def translate_values(list, from:, to:, **options)
       results = []
+
+      if ( glossary = glossary_for(from, to) )
+        options.merge!({ glossary_id: glossary.id })
+      end
+
       list.each_slice(BATCH_SIZE) do |parts|
         res = DeepL.translate(
           parts,
@@ -91,6 +96,13 @@ module I18n::Tasks::Translators
       else
         loc.upcase
       end
+    end
+
+    # Find the largest glossary given a language pair
+    def glossary_for(source, target)
+      DeepL.glossaries.list.select do |glossary|
+        glossary.source_lang == source && glossary.target_lang == target
+      end.sort_by(&:entry_count).last
     end
 
     def configure_api_key!

--- a/lib/i18n/tasks/translators/deepl_translator.rb
+++ b/lib/i18n/tasks/translators/deepl_translator.rb
@@ -24,7 +24,7 @@ module I18n::Tasks::Translators
     def translate_values(list, from:, to:, **options)
       results = []
 
-      if ( glossary = glossary_for(from, to) )
+      if (glossary = glossary_for(from, to))
         options.merge!({ glossary_id: glossary.id })
       end
 
@@ -102,7 +102,7 @@ module I18n::Tasks::Translators
     def glossary_for(source, target)
       DeepL.glossaries.list.select do |glossary|
         glossary.source_lang == source && glossary.target_lang == target
-      end.sort_by(&:entry_count).last
+      end.max_by(&:entry_count)
     end
 
     def configure_api_key!

--- a/spec/deepl_translate_spec.rb
+++ b/spec/deepl_translate_spec.rb
@@ -6,8 +6,14 @@ require 'deepl'
 
 RSpec.describe 'DeepL Translation' do
   nil_value_test  = ['nil-value-key', nil, nil]
-  text_test       = ['key', "Hello, %{user} O'Neill! How are you?", "¡Hola, %{user} O'Neill! ¿Qué tal estás?"]
-  html_test_plrl  = ['html-key.html.one', '<span>Hello %{count}</span>', '<span>Hola %{count}</span>']
+
+  text_test = [
+    'key',
+    "Hello, %{user} O'Neill! How are you? {{ Check out this Liquid tag, it should not be translated }} {% That applies to this Liquid tag as well %}",
+    "¡Hola, %{user} O'Neill! ¿Qué tal estás? {{ Check out this Liquid tag, it should not be translated }} {% That applies to this Liquid tag as well %}"
+  ]
+
+  html_test_plrl = ['html-key.html.one', '<span>Hello %{count} {{ count }} {% count %}</span>', '<span>Hola %{count} {{ count }} {% count %}</span>']
   array_test      = ['array-key', ['Hello.', nil, '', 'Goodbye.'], ['Hola.', nil, '', 'Adiós.']]
   array_hash_test = ['array-hash-key',
                      [{ 'hash_key1' => 'How are you?' }, { 'hash_key2' => nil }, { 'hash_key3' => 'Well.' }],

--- a/spec/deepl_translate_spec.rb
+++ b/spec/deepl_translate_spec.rb
@@ -5,15 +5,20 @@ require 'i18n/tasks/commands'
 require 'deepl'
 
 RSpec.describe 'DeepL Translation' do
-  nil_value_test  = ['nil-value-key', nil, nil]
+  nil_value_test = ['nil-value-key', nil, nil]
 
   text_test = [
     'key',
-    "Hello, %{user} O'Neill! How are you? {{ Check out this Liquid tag, it should not be translated }} {% That applies to this Liquid tag as well %}",
-    "¡Hola, %{user} O'Neill! ¿Qué tal estás? {{ Check out this Liquid tag, it should not be translated }} {% That applies to this Liquid tag as well %}"
+    "Hello, %{user} O'Neill! How are you? {{ Check out this Liquid tag, it should not be translated }} \
+    {% That applies to this Liquid tag as well %}",
+    "¡Hola, %{user} O'Neill! ¿Qué tal estás? {{ Check out this Liquid tag, it should not be translated }} \
+    {% That applies to this Liquid tag as well %}"
   ]
 
-  html_test_plrl = ['html-key.html.one', '<span>Hello %{count} {{ count }} {% count %}</span>', '<span>Hola %{count} {{ count }} {% count %}</span>']
+  html_test_plrl = [
+    'html-key.html.one', '<span>Hello %{count} {{ count }} {% count %}</span>',
+    '<span>Hola %{count} {{ count }} {% count %}</span>'
+  ]
   array_test      = ['array-key', ['Hello.', nil, '', 'Goodbye.'], ['Hola.', nil, '', 'Adiós.']]
   array_hash_test = ['array-hash-key',
                      [{ 'hash_key1' => 'How are you?' }, { 'hash_key2' => nil }, { 'hash_key3' => 'Well.' }],

--- a/spec/interpolations_spec.rb
+++ b/spec/interpolations_spec.rb
@@ -5,9 +5,6 @@ require 'spec_helper'
 RSpec.describe 'Interpolations' do
   let!(:task) { I18n::Tasks::BaseTask.new }
 
-  let(:base_keys) { { 'a' => 'hello %{world}', 'b' => 'foo', 'c' => { 'd' => 'hello %{name}' }, 'e' => 'ok' } }
-  let(:test_keys) { { 'a' => 'hello', 'b' => 'foo %{bar}', 'c' => { 'd' => 'hola %{amigo}' }, 'e' => 'ok' } }
-
   around do |ex|
     TestCodebase.setup(
       'config/i18n-tasks.yml' => { base_locale: 'en', locales: %w[es] }.to_yaml,
@@ -19,13 +16,63 @@ RSpec.describe 'Interpolations' do
     TestCodebase.teardown
   end
 
-  it '#inconsistent_interpolation' do
-    wrong  = task.inconsistent_interpolations
-    leaves = wrong.leaves.to_a
+  context 'ruby string interpolations' do
+    let(:base_keys) { { 'a' => 'hello %{world}', 'b' => 'foo', 'c' => { 'd' => 'hello %{name}' }, 'e' => 'ok' } }
+    let(:test_keys) { { 'a' => 'hello', 'b' => 'foo %{bar}', 'c' => { 'd' => 'hola %{amigo}' }, 'e' => 'ok' } }
 
-    expect(leaves.size).to eq 3
-    expect(leaves[0].full_key).to eq 'es.a'
-    expect(leaves[1].full_key).to eq 'es.b'
-    expect(leaves[2].full_key).to eq 'es.c.d'
+    it 'detects inconsistent interpolations' do
+      wrong  = task.inconsistent_interpolations
+      leaves = wrong.leaves.to_a
+
+      expect(leaves.size).to eq 3
+      expect(leaves[0].full_key).to eq 'es.a'
+      expect(leaves[1].full_key).to eq 'es.b'
+      expect(leaves[2].full_key).to eq 'es.c.d'
+    end
+  end
+
+  context 'liquid tags' do
+    let(:base_keys) do
+      {
+        a: 'hello {{ world }}',
+        b: 'foo',
+        c: {
+          d: 'hello {{ name }}'
+        },
+        e: 'ok',
+        f: 'inconsistent {{ whitespace}}',
+        g: 'includes a {% comment %}',
+        h: 'wrong {% comment %}',
+        i: 'with localized value: {{ "thanks" | owner_invoice }}',
+        j: 'with wrong function: {{ "thanks" | owner_invoices }}'
+      }
+    end
+    let(:test_keys) do
+      {
+        a: 'hello',
+        b: 'foo {{ bar }}',
+        c: {
+          d: 'hola {{ amigo }}'
+        },
+        e: 'ok',
+        f: '{{whitespace }} inconsistentes',
+        g: 'incluye un {% comment %}',
+        h: '{% commentario %} equivocado',
+        i: 'con valor localizado: {{ "gracias" | owner_invoice }}',
+        j: 'con función incorrecta: {{ "thanks" | owner_invoice }}'
+      }
+    end
+
+    it 'detects inconsistent interpolations' do
+      wrong  = task.inconsistent_interpolations
+      leaves = wrong.leaves.to_a
+
+      expect(leaves.size).to eq 5
+      expect(leaves[0].full_key).to eq 'es.a'
+      expect(leaves[1].full_key).to eq 'es.b'
+      expect(leaves[2].full_key).to eq 'es.c.d'
+      expect(leaves[3].full_key).to eq 'es.h'
+      expect(leaves[4].full_key).to eq 'es.j'
+    end
   end
 end

--- a/spec/interpolations_spec.rb
+++ b/spec/interpolations_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Interpolations' do
     TestCodebase.teardown
   end
 
-  context 'ruby string interpolations' do
+  context 'when using ruby string interpolations' do
     let(:base_keys) { { 'a' => 'hello %{world}', 'b' => 'foo', 'c' => { 'd' => 'hello %{name}' }, 'e' => 'ok' } }
     let(:test_keys) { { 'a' => 'hello', 'b' => 'foo %{bar}', 'c' => { 'd' => 'hola %{amigo}' }, 'e' => 'ok' } }
 
@@ -31,7 +31,7 @@ RSpec.describe 'Interpolations' do
     end
   end
 
-  context 'liquid tags' do
+  context 'when using liquid tags' do
     let(:base_keys) do
       {
         a: 'hello {{ world }}',


### PR DESCRIPTION
Adds liquid tag consistency validation to the interpolation check, and rebased from the original repository.

Additional validations:
* Content of {{ }} tags is the same, ignoring:
  * differences in whitespace around tags
  * Translation strings before the | passed to a function (e.g. {{ 'local language value' | method_name }}
* Content {% %} tags is the same, ignoring:
  * differences in whitespace around tags

Note that the following commits from our own for were removed in this rebase, since they were implemented in the original repository:

| Our Commit | Replacement |
| :----------- | :------------- |
| [Always set tag_handling to xml](https://github.com/glebm/i18n-tasks/commit/e8c1a8b73194e867ba6658be47e163fb713bcd35) | [DeepL: Default to tag_handling: xml](https://github.com/glebm/i18n-tasks/commit/249f0dd61b4e2a07befad96bed8e1f89b7527d3e) |
| [Fix warn_deprecated calls](https://github.com/glebm/i18n-tasks/commit/17606aa8ed429622e0e02c04ac92e4c1e20562ad) | [Fix private method called for warn deprecated](https://github.com/glebm/i18n-tasks/commit/7500affe061a3c5f4b83d31b2c921b9cedca14bd) |

**Considerations for merging**:
* This pull-request is relative to the 'main-base' branch, which is the same as the 'main' branch on the original
* Since this is a rebase, after merging the result has to be force-pushed to the existing main branch
* **WARNING: Please ensure that [the consistency fixes on monorepo](https://github.com/bookingexperts/monorepo/pull/8333) are on both staging and production, before merging this to main**

Closes bookingexperts/support#20321