### PR TITLE
21941 replaces the <i18n> interpolation tag in i18n-tasks for our cus…

### DIFF
--- a/spec/deepl_translate_spec.rb
+++ b/spec/deepl_translate_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe 'DeepL Translation' do
 
   text_test = [
     'key',
-    "Hello, %{user} O'Neill! How are you? {{ Check out this Liquid tag, it should not be translated }} \
-    {% That applies to this Liquid tag as well %}",
-    "¡Hola, %{user} O'Neill! ¿Qué tal estás? {{ Check out this Liquid tag, it should not be translated }} \
-    {% That applies to this Liquid tag as well %}"
+    "Hello, %{user} O'Neill! How are you? {{ Check out this Liquid tag, it should not be translated }} " \
+    '{% That applies to this Liquid tag as well %}',
+    "¡Hola, %{user} O'Neill! ¿Qué tal? {{ Check out this Liquid tag, it should not be translated }} " \
+    '{% That applies to this Liquid tag as well %}'
   ]
 
   html_test_plrl = [
@@ -90,6 +90,95 @@ RSpec.describe 'DeepL Translation' do
           ).to eq('<span>Coches</span> &lt;&lt; Camiones / %{keep_this}')
         end
       end
+    end
+  end
+
+  # Don't expect deepl's answers to be exactly the same each run
+  describe 'translating Dutch into other languages' do
+    let(:base_task) { I18n::Tasks::BaseTask.new }
+
+    before do
+      skip 'temporarily disabled on JRuby due to https://github.com/jruby/jruby/issues/4802' if RUBY_ENGINE == 'jruby'
+      skip 'DEEPL_AUTH_KEY env var not set' unless ENV['DEEPL_AUTH_KEY']
+    end
+
+    it 'tells time' do
+      german, english, spanish =
+        translate_dutch(hours_and_minutes: '%{hours} uur en %{minutes} minuten')
+      expect(german).to eq '%{hours} Stunden und %{minutes} Minuten'
+      expect(english).to eq '%{hours} hours and %{minutes} minutes'
+      expect(spanish).to eq '%{hours} horas y %{minutes} minutos'
+    end
+
+    it 'counts' do
+      german, english, spanish =
+        translate_dutch(other: '%{count} taken')
+      expect(german).to eq '%{count} Aufgaben'
+      expect(english).to eq '%{count} tasks'
+      expect(spanish).to eq '%{count} tareas'
+    end
+
+    it 'assigns' do
+      german, english, spanish =
+        translate_dutch(assigned: 'Taak "%{todo}" toegewezen aan %{user}')
+      expect(german).to eq 'To-dos "%{todo}" zugewiesen an %{user}'
+      expect(english).to eq 'Task "%{todo}" assigned to %{user}'
+      expect(spanish).to eq 'Tarea "%{todo}" asignada a %{user}'
+    end
+
+    it 'sings' do
+      german, english, spanish =
+        translate_dutch(verse: 'Ik zou zo graag een %{animal} kopen. Ik zag %{count} beren %{food} smeren')
+      expect(german).to eq 'Ich würde so gerne einen %{animal} kaufen. Ich sah %{count} Bären, die %{food} schmierten'
+      # greasing is a funny way to say smeren, but we let it slide
+      expect(english).to eq 'I would so love to buy a %{animal}. I saw %{count} bears greasing %{food}'
+      expect(spanish).to eq 'Me encantaría comprar un %{animal}. Vi %{count} osos engrasando %{food}'
+    end
+
+    it 'sends emails' do
+      german, english, spanish =
+        translate_dutch(
+          email_body_html: '{{ booking.greeting }},<br><br>Bijgevoegd ziet u een factuur van {{ park.name }} met ' \
+                           'factuurnummer {{ invoice.invoice_nr }}.<br />Volgens onze administratie had het ' \
+                           'verschuldigde bedrag van {{ locals.payment_collector_total }} op  ' \
+                           '{{ locals.payment_collector_deadline }} moeten zijn betaald. Helaas hebben we nog ' \
+                           'geen betaling ontvangen.<br>'
+        )
+      expect(german).to eq '{{ booking.greeting }},<br /><br />Anbei finden Sie eine Rechnung von {{ park.name }} ' \
+                           'mit der Rechnungsnummer {{ invoice.invoice_nr }}.<br />Laut unserer Verwaltung hätte der ' \
+                           'von {{ locals.payment_collector_total }} geschuldete Betrag ' \
+                           'am {{ locals.payment_collector_deadline }} bezahlt werden müssen. Leider haben wir die ' \
+                           'Zahlungen noch nicht erhalten.<br />'
+      expect(english).to eq '{{ booking.greeting }},<br /><br />Attached please find an invoice from {{ park.name }} ' \
+                            'with invoice number {{ invoice.invoice_nr }}.<br />According to our records, the amount ' \
+                            'due from {{ locals.payment_collector_total }} on ' \
+                            '{{ locals.payment_collector_deadline }} should have been paid. Unfortunately, we have ' \
+                            'not yet received payment.<br />'
+      expect(spanish).to eq '{{ booking.greeting }},<br /><br />Adjuntamos una factura de {{ park.name }} con el ' \
+                            'número de factura {{ invoice.invoice_nr }}.<br />Según nuestros registros, el importe ' \
+                            'adeudado por {{ locals.payment_collector_total }} debería haber sido abonado en ' \
+                            '{{ locals.payment_collector_deadline }}. Lamentablemente, aún no hemos recibido ' \
+                            'el pago.<br />'
+    end
+
+    it 'asks itself why are you even translating this' do
+      german, english, spanish =
+        translate_dutch(action: '%{subject} %{verb} %{object}')
+      expect(german).to eq '%{subject} %{verb} %{object}'
+      expect(english).to eq '%{subject} %{verb} %{object}'
+      expect(spanish).to eq '%{subject} %{verb} %{object}'
+    end
+
+    def translate_dutch(dutch_pair)
+      key = dutch_pair.keys.first
+      phrase = dutch_pair[key]
+      locales = %w[de en-us es]
+      branches = locales.each_with_object({}) do |locale, hash|
+        hash[locale] = { 'testing' => { key => phrase } }
+      end
+      tree = build_tree(branches)
+      translations = base_task.translate_forest(tree, from: 'nl', backend: :deepl)
+      locales.map { |locale| translations[locale]['testing'][key].value.strip }
     end
   end
 end


### PR DESCRIPTION
i18n-tasks normally send DeepL something like:
Taak "&lt;i18n>%{todo}&lt;/i18n>" toegewezen aan &lt;i18n>%{user}&lt;/i18n>
and gets back
&lt;i18n>%{todo}&lt;/i18n>To-dos " " zugewiesen an &lt;i18n>%{user}&lt;/i18n>
That mess is the reason why this PR is needed

In this PR we send a custom &lt;var> tag like:
Taak &quot;&lt;var handle="%{todo}" sub="RYX">RYX&lt;/var>&quot; toegewezen aan &lt;var handle="%{user}" sub="QFN">QFN&lt;/var>
and get back
To-dos &quot;&lt;var handle="%{todo}" sub="RYX">RYX&lt;/var>&quot; zugewiesen an &lt;var handle="%{user}" sub="QFN">QFN&lt;/var>

XML attributes, handle and sub, aren't modified by DeepL, so we can rely on those to come back with the same values we sent, enabling us to undo the substitution.

Now we can allow DeepL to "read" the tags (whereas before they were ignored), and that makes for better translations, and solves the problem of interpolations getting pushed to the front.

What we get back isn't all sunshine and rainbows, though, DeepL will still occasionally mangle it. More details in the code.