### PR TITLE
Make DeepL able to translate to variants.

### DIFF
--- a/lib/i18n/tasks/translators/deepl_translator.rb
+++ b/lib/i18n/tasks/translators/deepl_translator.rb
@@ -47,7 +47,20 @@ module I18n::Tasks::Translators
     end
 
     def options_for_translate_values(**options)
-      extra_options = @i18n_tasks.translation_config[:deepl_options]&.symbolize_keys || {}
+      extra_options = @i18n_tasks.translation_config[:deepl_options]&.deep_symbolize_keys || {}
+
+      from = options.fetch(:from)
+      to = options.fetch(:to)
+      if target_is_variant_of_source?(from, to)
+        # DeepL does not allow translatinging to a variant of a source (en->en-us).
+        # When doing so, it will return the same translation back.
+        # However, somehow, when specifying that the source language is some other language,
+        # deepl does allow translating it. Choosing German as it well supported language in deepl next to English,
+        # although it probably will not matter.
+        # Quite the weird hack, but as long as it works 🤷
+        target_is_en = to_deepl_target_locale(to).split("-").first == "EN"
+        options[:from] = target_is_en ? "de" : "en"
+      end
 
       extra_options.merge({ignore_tags: %w[i18n]}).merge(options)
     end
@@ -182,6 +195,14 @@ module I18n::Tasks::Translators
       else
         loc.upcase
       end
+    end
+
+    # Checks if the target is a variant of the source. (e.g EN -> EN-GB)
+    def target_is_variant_of_source?(from, to)
+      deepl_source_locale = to_deepl_source_locale(from)
+      deepl_target_locale = to_deepl_target_locale(to)
+
+      deepl_source_locale == deepl_target_locale.split("-").first
     end
 
     # Find the largest glossary given a language pair

--- a/spec/translators/deepl_translate_spec.rb
+++ b/spec/translators/deepl_translate_spec.rb
@@ -35,8 +35,15 @@ RSpec.describe "DeepL Translation" do
   describe "real world test" do
     delegate :i18n_task, :in_test_app_dir, :run_cmd, to: :TestCodebase
 
+    let(:config) do
+      {base_locale: "en", locales: %w[es], translation: {backend: "deepl"}}
+    end
+
     before do
-      TestCodebase.setup("config/locales/en.yml" => "", "config/locales/es.yml" => "")
+      TestCodebase.setup(
+        "config/locales/en.yml" => "", "config/locales/es.yml" => "",
+        "config/i18n-tasks.yml" => config.to_yaml
+      )
     end
 
     after do
@@ -75,7 +82,7 @@ RSpec.describe "DeepL Translation" do
             }
           })
 
-          run_cmd "translate-missing", "--backend=deepl"
+          run_cmd "translate-missing"
           expect(task.t("common.hello", "es")).to eq(text_test[2])
           expect(task.t("common.hello_plural_html.one", "es")).to eq(html_test_plrl[2])
           expect(task.t("common.array_key", "es")).to eq(array_test[2])
@@ -121,6 +128,38 @@ RSpec.describe "DeepL Translation" do
           ["Hello"],
           "EN",
           "PT-BR",
+          {html_escape: true, ignore_tags: ["i18n"], preserve_formatting: true, tag_handling: "xml"}
+        ).once
+
+        TestCodebase.run_cmd "translate-missing"
+      end
+    end
+  end
+
+  describe "translating variants" do
+    let(:config) do
+      {base_locale: "en", locales: %w[en-US], translation: {backend: "deepl"}}
+    end
+
+    before do
+      TestCodebase.setup(
+        "config/locales/en.yml" => {en: {hello: "Hello"}}.to_yaml, "config/locales/en-US.yml" => "",
+        "config/i18n-tasks.yml" => config.to_yaml
+      )
+    end
+
+    after do
+      TestCodebase.teardown
+    end
+
+    context "when configuration has en=>en-US" do
+      it "uses hack to make source locale DE instead of EN" do
+        skip "DEEPL_AUTH_KEY env var not set" unless ENV["DEEPL_AUTH_KEY"]
+
+        expect(DeepL).to receive(:translate).with(
+          ["Hello"],
+          "DE",
+          "EN-US",
           {html_escape: true, ignore_tags: ["i18n"], preserve_formatting: true, tag_handling: "xml"}
         ).once
 


### PR DESCRIPTION
DeepL does not support translating from `en` -> `en-US`.
However, if one specifies that the source locale isn't english (even though it is). It seems to work 🤷.

